### PR TITLE
require "change note" for editing achievements assigned to a batch

### DIFF
--- a/app/achievements/views/staff.py
+++ b/app/achievements/views/staff.py
@@ -201,6 +201,7 @@ def set_achievement_rating(req, data, achievement):
             "description": StringType(min_length=1, max_length=2048),
             "solution": StringType(max_length=2048),
             "tags": StringType(max_length=128),
+            "change_note": StringType(max_length=512, optional=True),
             "beatmaps": ListType(
                 DictionaryType({"id": IntegerType(), "hide": BoolType()}),
                 unique=True,
@@ -238,6 +239,8 @@ def create_achievement(req, data, achievement=None):
     elif achievement.creator_id != req.user.id and not req.user.is_admin:
         return error("cannot edit an achievement that's not yours")
     else:
+        if achievement.batch_id is not None and not data.get("change_note"):
+            return error("change note is required for batched achievements")
         if (
             achievement.batch_id is not None
             and achievement.batch.release_time <= datetime.now(tz=timezone.utc)
@@ -254,7 +257,7 @@ def create_achievement(req, data, achievement=None):
         achievement.algorithm_enabled = data["algorithm_enabled"]
         achievement.save()
 
-        discord_logger.submit_achievement(req, achievement, "edited")
+        discord_logger.submit_achievement(req, achievement, "edited", data.get("change_note"))
 
     comm.refresh_achievements_on_server()
 

--- a/app/common/discord.py
+++ b/app/common/discord.py
@@ -84,7 +84,7 @@ class DiscordLogger:
 
         self.submit_embeds(_create_error_embeds(req, exc), self.ERROR_WEBHOOK_URL)
 
-    def submit_achievement(self, req, achievement, action):
+    def submit_achievement(self, req, achievement, action, note=None):
         if self.STAFF_WEBHOOK_URL is None:
             _log.warning("Unable to log new achievement, STAFF_WEBHOOK_URL is None")
             return
@@ -106,6 +106,9 @@ class DiscordLogger:
             "author": _create_author_info(req.user),
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
+
+        if note:
+            embed["fields"] = [{"name": "Change note", "value": note[:1024]}]
 
         self.submit_embeds([embed], self.STAFF_WEBHOOK_URL)
 

--- a/app/frontend/src/routes/staff/creation.tsx
+++ b/app/frontend/src/routes/staff/creation.tsx
@@ -161,6 +161,7 @@ type ViewProps = {
 class CreationViewComponent extends React.Component<ViewProps> {
   private payload: AchievementPayloadType;
   private timeoutId: number | null = null;
+  private changeNote = "";
   state = {
     saving: false,
   };
@@ -312,6 +313,7 @@ class CreationViewComponent extends React.Component<ViewProps> {
       beatmaps: payload.beatmaps,
       solution_algorithm: payload.solutionAlgorithm,
       algorithm_enabled: payload.algorithmEnabled,
+      change_note: this.changeNote.trim(),
     };
   }
 
@@ -418,6 +420,19 @@ class CreationViewComponent extends React.Component<ViewProps> {
               value={this.payload.solution}
               setValue={(value) => this.editAchievement("solution", value)}
             />
+            {this.payload.id !== null ? (
+              <TextArea
+                placeholder="Change note for this edit"
+                className="staff-creation__input"
+                value={this.changeNote}
+                setValue={(value) => {
+                  this.changeNote = value;
+                  this.forceUpdate();
+                }}
+              />
+            ) : (
+              ""
+            )}
             <Select
               isMulti
               name="tags"

--- a/app/frontend/src/routes/staff/creation.tsx
+++ b/app/frontend/src/routes/staff/creation.tsx
@@ -58,6 +58,7 @@ type CompactAchievementPayloadType = {
   }[];
   solutionAlgorithm: SolutionAlgorithmData;
   algorithmEnabled: boolean;
+  change_note: string;
 };
 
 type AchievementPayloadType = Omit<CompactAchievementPayloadType, "tags"> & {
@@ -76,6 +77,7 @@ function makeDefaultPayload(): AchievementPayloadType {
     solutionAlgorithm: makeBlankSolutionAlgorithm(),
     algorithmEnabled: false,
     mode: "any",
+    change_note: "",
   };
 }
 
@@ -123,6 +125,7 @@ function makeAchievementPayload(
     solutionAlgorithm: achievement.solution_algorithm,
     algorithmEnabled: achievement.algorithm_enabled,
     mode,
+    change_note: "",
   };
 }
 
@@ -161,7 +164,6 @@ type ViewProps = {
 class CreationViewComponent extends React.Component<ViewProps> {
   private payload: AchievementPayloadType;
   private timeoutId: number | null = null;
-  private changeNote = "";
   state = {
     saving: false,
   };
@@ -313,7 +315,7 @@ class CreationViewComponent extends React.Component<ViewProps> {
       beatmaps: payload.beatmaps,
       solution_algorithm: payload.solutionAlgorithm,
       algorithm_enabled: payload.algorithmEnabled,
-      change_note: this.changeNote.trim(),
+      change_note: payload.change_note,
     };
   }
 
@@ -424,9 +426,9 @@ class CreationViewComponent extends React.Component<ViewProps> {
               <TextArea
                 placeholder="Change note for this edit"
                 className="staff-creation__input"
-                value={this.changeNote}
+                value={this.payload.change_note}
                 setValue={(value) => {
-                  this.changeNote = value;
+                  this.payload.change_note = value;
                   this.forceUpdate();
                 }}
               />


### PR DESCRIPTION
I thought it could be helpful to have a change note when editing achievements that have been moved to a batch already. I locally tested the change but not whether the note is actually embedded into the discord logger.